### PR TITLE
feat: Facebook token acceptance from the url for mobile app auth

### DIFF
--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import Cookies from 'js-cookie';
 import type { NextPage } from 'next';
+import { useEffect } from 'react';
 import FacebookLogin from 'react-facebook-login/dist/facebook-login-render-props';
 
 import AuthLayout from '../components/layout/Auth.layout';
@@ -16,10 +17,18 @@ const Home: NextPage = () => {
     );
 
     Cookies.set('token', data.accessToken);
-    Cookies.set('profile', response.picture.data.url);
+    Cookies.set('profile', response.picture?.data.url);
 
     window.location.href = '/';
   };
+
+  useEffect(() => {
+    const url = new URL(location.href)
+    const facebookToken = url.searchParams.get('token')
+    if(facebookToken !== null){
+      loginUser({accessToken: facebookToken})
+    }
+  }, [])
 
   return (
     <AuthLayout>


### PR DESCRIPTION
This feature is implemented for easy authentication with mobile applications.

On the login page, if the URL contains a GET token variable, then instead of the user getting a token with the ` sign in with facebook` button, the GET is extracted and try to login to the backend with the extracted token. 